### PR TITLE
mavenCentral added to buildscript repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ buildscript {
 	    maven { url "http://repo.spring.io/snapshot" }
 	    maven { url "http://repo.spring.io/milestone" }
 	    maven { url "http://repo.spring.io/release" }
+	    mavenCentral()
 	    mavenLocal()
     }
     dependencies {


### PR DESCRIPTION
Otherwise, commons-logging library could not be resolved.
